### PR TITLE
Added simple overload mechanism to allow provision of custom tags

### DIFF
--- a/Hound.Tests/LogHoundTests.cs
+++ b/Hound.Tests/LogHoundTests.cs
@@ -1,5 +1,6 @@
 ﻿using Shouldly;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Hound.Tests
@@ -24,6 +25,20 @@ namespace Hound.Tests
             catch (HoundException ex)
             {
                 HoundResult result = LogHound.LogException(_testApiKey, ex);
+                result.IsSuccess.ShouldBeTrue();
+            }
+        }
+
+        [Fact]
+        public void TestExceptionWithTagsShouldBeSuccess()
+        {
+            try
+            {
+                throw new TestException("Hound-001", "Sheridan Le Fanu");
+            }
+            catch (HoundException ex)
+            {
+                HoundResult result = LogHound.LogException(_testApiKey, ex, new List<string>() { "test", "exception" });
                 result.IsSuccess.ShouldBeTrue();
             }
         }

--- a/Hound/Datadog/EventRequest.cs
+++ b/Hound/Datadog/EventRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Hound.Datadog
 {
@@ -12,6 +13,9 @@ namespace Hound.Datadog
 
         [JsonProperty(PropertyName = "host")]
         public string Host { get; set; }
+
+        [JsonProperty(PropertyName = "tags")]
+        public IEnumerable<string> Tags { get; set; }
 
         [JsonProperty(PropertyName = "alert_type")]
         public string AlertType { get; set; }

--- a/Hound/DogExceptions.cs
+++ b/Hound/DogExceptions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Hound
 {
@@ -12,7 +13,7 @@ namespace Hound
             _eventDestination = eventDestination;
         }
 
-        public async Task<HoundResult> Publish(HoundException exception)
+        public async Task<HoundResult> Publish(HoundException exception, IEnumerable<string> tags = null)
         {
             HoundEvent houndEvent = new HoundEvent
             {
@@ -20,7 +21,8 @@ namespace Hound
                 AlertType = exception.Severity,
                 Host = exception.HostName,
                 Text = exception.ToString(),
-                Title = exception.Message
+                Title = exception.Message,
+                Tags = tags ?? new List<string>()
             };
 
             return await _eventDestination.Publish(houndEvent);

--- a/Hound/Events/HoundEventMapper.cs
+++ b/Hound/Events/HoundEventMapper.cs
@@ -15,7 +15,8 @@ namespace Hound.Events
                 Host = houndEvent.Host,
                 SourceTypeName = houndEvent.SourceTypeName,
                 Text = houndEvent.Text,
-                Title = houndEvent.Title
+                Title = houndEvent.Title,
+                Tags = houndEvent.Tags
             };
 
             HttpContent content = new StringContent(JsonConvert.SerializeObject(eventRequest));

--- a/Hound/HoundEvent.cs
+++ b/Hound/HoundEvent.cs
@@ -1,4 +1,6 @@
-﻿namespace Hound
+﻿using System.Collections.Generic;
+
+namespace Hound
 {
     public class HoundEvent
     {
@@ -16,6 +18,11 @@
         /// The machine, container, or other identity of where the event occurred
         /// </summary>
         public string Host { get; set; }
+
+        /// <summary>
+        /// A list of tags to apply to the event
+        /// </summary>
+        public IEnumerable<string> Tags { get; set; }
 
         /// <summary>
         /// The severity of the event

--- a/Hound/IExceptionDestination.cs
+++ b/Hound/IExceptionDestination.cs
@@ -1,9 +1,10 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace Hound
 {
     public interface IExceptionDestination
     {
-        Task<HoundResult> Publish(HoundException exception);
+        Task<HoundResult> Publish(HoundException exception, IEnumerable<string> tags = null);
     }
 }

--- a/Hound/LogHound.cs
+++ b/Hound/LogHound.cs
@@ -1,5 +1,6 @@
 ﻿using Hound.Result;
 using System;
+using System.Collections.Generic;
 
 namespace Hound
 {
@@ -9,14 +10,21 @@ namespace Hound
         {
             try
             {
-                HoundException houndException = exception as HoundException;
+                HoundException houndException = CastException(exception);
+                return Log(apiKey).Publish(houndException).Result;
+            }
+            catch (Exception ex)
+            {
+                return HoundResultMapper.GetFailureResponse(ex);
+            }
+        }     
 
-                if (houndException == null)
-                {
-                    houndException = new HoundException(exception);
-                }
-
-                return Log(apiKey, houndException);
+        public static HoundResult LogException(string apiKey, Exception exception, IEnumerable<string> tags)
+        {
+            try
+            {
+                HoundException houndException = CastException(exception);
+                return Log(apiKey).Publish(houndException, tags).Result;
             }
             catch (Exception ex)
             {
@@ -24,11 +32,22 @@ namespace Hound
             }
         }
 
-        private static HoundResult Log(string apiKey, HoundException exception)
+        private static HoundException CastException(Exception exception)
+        {
+            HoundException houndException = exception as HoundException;
+
+            if (houndException == null)
+            {
+                houndException = new HoundException(exception);
+            }
+
+            return houndException;
+        }
+
+        private static IExceptionDestination Log(string apiKey)
         {
             IEventDestination eventDestination = new DogEvents(apiKey);
-            IExceptionDestination exceptionDestination = new DogExceptions(eventDestination);
-            return exceptionDestination.Publish(exception).Result;
+            return new DogExceptions(eventDestination);
         }
     }
 }


### PR DESCRIPTION
We needed a method to provide tags with our events as these are no longer supplied automatically by the agent. An overload on the public method was the cleanest way I could think of doing this as tags don't belong on the exception itself. 

This does mean however, that there is a default on the IEventDestination interface. Which I am not sure I am happy with and it seemed just as much overkill to overload all the Publish methods down the chain. I couldn't think of a pattern that would fit though. Other ideas welcome!