### PR TITLE
Fix deadlock when running on net461 projects

### DIFF
--- a/Hound/LogHound.cs
+++ b/Hound/LogHound.cs
@@ -1,5 +1,6 @@
 ﻿using Hound.Result;
 using System;
+using System.Threading.Tasks;
 
 namespace Hound
 {
@@ -28,7 +29,7 @@ namespace Hound
         {
             IEventDestination eventDestination = new DogEvents(apiKey);
             IExceptionDestination exceptionDestination = new DogExceptions(eventDestination);
-            return exceptionDestination.Publish(exception).Result;
+            return Task.Run(async() => await exceptionDestination.Publish(exception)).Result;
         }
     }
 }


### PR DESCRIPTION
The .result on the LogException method return is causing deadlock when running on 461 applications and is causing web applications to lose their context meaning that they just hang forever. I have wrapped the aysnc method call in a Task.Run with an await and called result on that instead so context is preserved.